### PR TITLE
Added one.com to community_sealer_whitelist

### DIFF
--- a/community_sealer_whitelist
+++ b/community_sealer_whitelist
@@ -3,3 +3,4 @@ messagingengine.com
 pobox.com
 topicbox.com
 umich.edu
+one.com


### PR DESCRIPTION
We're signing all mails we forward for our customers at one.com. I'm assuming you'll want to do some verification so let me know if you need anything for that.