### PR TITLE
Added securemx.jp to community_sealer_whitelist

### DIFF
--- a/community_sealer_whitelist
+++ b/community_sealer_whitelist
@@ -8,3 +8,4 @@ umich.edu
 fastmail.com
 fastmail.fm
 one.com
+securemx.jp


### PR DESCRIPTION
As we have joined ARC interop exercise in October 2018, we are signing all incoming mails we forward to our customers at securemx.jp.  You can verify it currently but please let me know if I can anything to do.