### PR TITLE
Update community_sealer_whitelist

### DIFF
--- a/community_sealer_whitelist
+++ b/community_sealer_whitelist
@@ -9,3 +9,5 @@ fastmail.com
 fastmail.fm
 one.com
 securemx.jp
+zone.eu
+teliaklm.ee


### PR DESCRIPTION
Added Telia Eesti AS and Zone Media OÜ (https://help.zone.eu/kb/arc-authenticated-received-chain/) to ARC signers list. Both add ARC signatures and follow the DMARC standard.